### PR TITLE
BT-8129: Pass cookie, allocator, and deallocator to ubpf_create

### DIFF
--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -33,7 +33,21 @@
 struct ubpf_vm;
 typedef uint64_t (*ubpf_jit_fn)(void *mem, size_t mem_len);
 
-struct ubpf_vm *ubpf_create(void);
+typedef void *(*ubpf_zmalloc_fn)(void *cookie, size_t size);
+typedef void *(*ubpf_free_fn)(void *ptr);
+
+/*
+ * Create ubmf vm
+ *
+ * Zmalloc_cookie and pointers to zmalloc and free functions are stored
+ * in the ubpf_vm struct.
+ * Zmalloc function is invoked for allocation with zmalloc_cookie passed
+ * as parameter; free function is invoked for deallocation.
+ */
+struct ubpf_vm *
+ubpf_create(void *zmalloc_cookie,
+            ubpf_zmalloc_fn zmalloc_fn,
+            ubpf_free_fn free_fn);
 void ubpf_destroy(struct ubpf_vm *vm);
 
 /*

--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -37,7 +37,7 @@ typedef void *(*ubpf_zmalloc_fn)(void *cookie, size_t size);
 typedef void *(*ubpf_free_fn)(void *ptr);
 
 /*
- * Create ubmf vm
+ * Create ubmf vm with specified allocator and deallocator
  *
  * Zmalloc_cookie and pointers to zmalloc and free functions are stored
  * in the ubpf_vm struct.
@@ -45,9 +45,16 @@ typedef void *(*ubpf_free_fn)(void *ptr);
  * as parameter; free function is invoked for deallocation.
  */
 struct ubpf_vm *
-ubpf_create(void *zmalloc_cookie,
-            ubpf_zmalloc_fn zmalloc_fn,
-            ubpf_free_fn free_fn);
+ubpf_create_ext(void *zmalloc_cookie,
+                ubpf_zmalloc_fn zmalloc_fn,
+                ubpf_free_fn free_fn);
+
+/*
+ * Create ubmf vm with default allocator and deallocator
+ */
+struct ubpf_vm *
+ubpf_create(void);
+
 void ubpf_destroy(struct ubpf_vm *vm);
 
 /*

--- a/vm/ubpf_int.h
+++ b/vm/ubpf_int.h
@@ -33,6 +33,9 @@ struct ubpf_vm {
     bool bounds_check_enabled;
     int (*error_printf)(FILE* stream, const char* format, ...);
     int unwind_stack_extension_index;
+    void *zmalloc_cookie;
+    ubpf_zmalloc_fn zmalloc_fn;
+    ubpf_free_fn free_fn;
 };
 
 char *ubpf_error(const char *fmt, ...);

--- a/vm/ubpf_loader.c
+++ b/vm/ubpf_loader.c
@@ -143,7 +143,7 @@ ubpf_load_elf(struct ubpf_vm *vm, const void *elf, size_t elf_size, char **errms
     struct section *text = &sections[text_shndx];
 
     /* May need to modify text for relocations, so make a copy */
-    text_copy = malloc(text->size);
+    text_copy = vm->zmalloc_fn(vm->zmalloc_cookie, text->size);
     if (!text_copy) {
         *errmsg = ubpf_error("failed to allocate memory");
         goto error;
@@ -218,10 +218,10 @@ ubpf_load_elf(struct ubpf_vm *vm, const void *elf, size_t elf_size, char **errms
     }
 
     int rv = ubpf_load(vm, text_copy, sections[text_shndx].size, errmsg);
-    free(text_copy);
+    vm->free_fn(text_copy);
     return rv;
 
 error:
-    free(text_copy);
+    vm->free_fn(text_copy);
     return -1;
 }

--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -45,9 +45,9 @@ void ubpf_set_error_print(struct ubpf_vm *vm, int (*error_printf)(FILE* stream, 
 }
 
 struct ubpf_vm *
-ubpf_create(void *zmalloc_cookie,
-            ubpf_zmalloc_fn zmalloc_fn,
-            ubpf_free_fn free_fn)
+ubpf_create_ext(void *zmalloc_cookie,
+                ubpf_zmalloc_fn zmalloc_fn,
+                ubpf_free_fn free_fn)
 {
     struct ubpf_vm *vm = zmalloc_fn(zmalloc_cookie, sizeof(*vm));
     if (vm == NULL) {
@@ -77,6 +77,26 @@ ubpf_create(void *zmalloc_cookie,
 
     vm->unwind_stack_extension_index = -1;
     return vm;
+}
+
+
+static void *
+default_zmalloc(void * cookie, size_t size)
+{
+    return calloc(1, size);
+}
+
+static void *
+default_free(void *ptr)
+{
+    free(ptr);
+    return NULL;
+}
+
+struct ubpf_vm *
+ubpf_create(void)
+{
+    return ubpf_create_ext(NULL, default_zmalloc, default_free);
 }
 
 void


### PR DESCRIPTION
Reviewer: @3mp4y5 
Pass zmalloc_cookie and zmalloc and free functions to ubpf_create, used for allocation and deallocation